### PR TITLE
add option to set -o output path

### DIFF
--- a/writenow
+++ b/writenow
@@ -68,14 +68,16 @@ function usage() {
   echo "Usage: writenow [OPTION]..."
   echo
   echo "Examples:"
+  echo "  writenow"
   echo "  writenow -o note.txt"
   echo "  writenow -o ~/notes/\$(date +%Y-%m-%d).txt"
   echo
   echo "Options:"
-  echo "  -o <path>       filepath where lines will be appended."
+  echo "  -o <path>       Filepath where lines will be appended."
   echo "                  If omitted, a filepath prompt appears upon exit."
-  echo "  -h, --help      display this help and exit"
-  echo "  -v, --version   display version information and exit"
+  echo "                  If you Ctrl+C the prompt, then nothing will be saved."
+  echo "  -h, --help      Display this help and exit"
+  echo "  -v, --version   Display version information and exit"
   echo
 }
 

--- a/writenow
+++ b/writenow
@@ -25,6 +25,7 @@ readonly SECOND_COLOR="8"
 declare -r -i MAX_ROWS=3
 declare -i ROWS=0
 declare ROW_LINES=()
+declare TERMINATED=false
 declare OUTPATH=""
 
 # Print a colored message
@@ -125,10 +126,17 @@ function write_lines() {
   echo "" >> "$1"
 }
 
-# Handle termination signals
-# Globals: OUTPATH
+# Handle termination signals and write output
+# Globals: OUTPATH, TERMINATED
 function handle_termination() {
+  if $TERMINATED; then
+    echo
+    exit 0
+  fi
+
+  TERMINATED=true
   if [[ -z "$OUTPATH" ]]; then
+    echo
     read -r -p "File name to write: " OUTPATH
   fi
   write_lines "${OUTPATH}"

--- a/writenow
+++ b/writenow
@@ -3,7 +3,7 @@
 # writenow - A simple bash script to write in edit-free mode
 #
 # Copyright (C) 2023  Salar Nosrati-Ershad
-# Modified in 2025 by Justin Wong
+# Copyright (C) 2025  Justin Wong
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,12 +51,12 @@ function err() {
 # Output: version information on stdout
 function version() {
   echo "writenow ${VERSION}"
-#  echo
-#  echo "Copyright (C)  2023 Salar Nosrati-Ershad"
-#  echo "Modified in 2025 by Justin Wong"
-#  echo "License GPLv3: GNU GPL version 3 <https://gnu.org/licenses/gpl.html>"
-#  echo "This is free software: you are free to change and redistribute it."
-#  echo "There is NO WARRANTY, to the extent permitted by law."
+  echo
+  echo "Copyright (C)  2023 Salar Nosrati-Ershad"
+  echo "Copyright (C)  2025 Justin Wong"
+  echo "License GPLv3: GNU GPL version 3 <https://gnu.org/licenses/gpl.html>"
+  echo "This is free software: you are free to change and redistribute it."
+  echo "There is NO WARRANTY, to the extent permitted by law."
 }
 
 # Show usage information

--- a/writenow
+++ b/writenow
@@ -67,8 +67,11 @@ function usage() {
   echo
   echo "Usage: writenow [OPTION]..."
   echo
-  echo "Example: writenow -o ~/notes/\$(date +%Y-%m-%d).txt"
+  echo "Examples:"
+  echo "  writenow -o note.txt"
+  echo "  writenow -o ~/notes/\$(date +%Y-%m-%d).txt"
   echo
+  echo "Options:"
   echo "  -o <path>       filepath where lines will be appended."
   echo "                  If omitted, a filepath prompt appears upon exit."
   echo "  -h, --help      display this help and exit"

--- a/writenow
+++ b/writenow
@@ -3,6 +3,7 @@
 # writenow - A simple bash script to write in edit-free mode
 #
 # Copyright (C) 2023  Salar Nosrati-Ershad
+# Modified in 2025 by Justin Wong
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,7 +18,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 # Global variables
-readonly VERSION="v0.1.3"
+readonly VERSION="v0.2.0"
 readonly PROMPT="> "
 readonly ERROR_COLOR="1"
 readonly SECOND_COLOR="8"
@@ -49,10 +50,12 @@ function err() {
 # Output: version information on stdout
 function version() {
   echo "writenow ${VERSION}"
-  echo "Copyright (C)  2023 Salar Nosrati-Ershad"
-  echo "License GPLv3: GNU GPL version 3 <https://gnu.org/licenses/gpl.html>"
-  echo "This is free software: you are free to change and redistribute it."
-  echo "There is NO WARRANTY, to the extent permitted by law."
+#  echo
+#  echo "Copyright (C)  2023 Salar Nosrati-Ershad"
+#  echo "Modified in 2025 by Justin Wong"
+#  echo "License GPLv3: GNU GPL version 3 <https://gnu.org/licenses/gpl.html>"
+#  echo "This is free software: you are free to change and redistribute it."
+#  echo "There is NO WARRANTY, to the extent permitted by law."
 }
 
 # Show usage information

--- a/writenow
+++ b/writenow
@@ -25,6 +25,7 @@ readonly SECOND_COLOR="8"
 declare -r -i MAX_ROWS=3
 declare -i ROWS=0
 declare ROW_LINES=()
+declare OUTPATH=""
 
 # Print a colored message
 # Arguments: message, color
@@ -65,9 +66,10 @@ function usage() {
   echo
   echo "Usage: writenow [OPTION]..."
   echo
-  echo "  Upon exit, writenow will create a file at ~/prose/\$(date +%Y-%m-%d).txt"
-  echo "  if it does not already exist, and then append the lines you've written."
+  echo "Example: writenow -o ~/notes/\$(date +%Y-%m-%d).txt"
   echo
+  echo "  -o <path>       filepath where lines will be appended."
+  echo "                  If omitted, a filepath prompt appears upon exit."
   echo "  -h, --help      display this help and exit"
   echo "  -v, --version   display version information and exit"
   echo
@@ -77,8 +79,14 @@ function usage() {
 # Arguments: first arguments
 # Output: error message on stderr and exit if arguments are invalid
 # Return: 0 if arguments are valid, 1 otherwise
+# Globals: OUTPATH
 function parse_args() {
   case "$1" in
+    -o)
+      OUTPATH="$2"
+      # TODO: touch outpath, and quit with err early if cannot write to that path,
+      # like in the case of missing permissions or directory not existing
+      ;;
     -h|--help)
       usage
       exit 0
@@ -118,9 +126,11 @@ function write_lines() {
 }
 
 # Handle termination signals
+# Globals: OUTPATH
 function handle_termination() {
-  mkdir -p "$HOME/prose"
-  local OUTPATH="$HOME/prose/$(date +%Y-%m-%d).txt"
+  if [[ -z "$OUTPATH" ]]; then
+    read -r -p "File name to write: " OUTPATH
+  fi
   write_lines "${OUTPATH}"
   echo
   echo "added ${#ROW_LINES[@]} lines to ${OUTPATH}" >&2
@@ -166,7 +176,8 @@ function prompt_loop() {
 function main() {
   # parse arguments
   if [[ $# -gt 0 ]]; then
-    parse_args "$1"
+    # pass all args to parse_args func
+    parse_args "$@"
   fi
 
   # Check dependencies

--- a/writenow
+++ b/writenow
@@ -125,8 +125,6 @@ function write_lines() {
   for row in "${ROW_LINES[@]}"; do
     echo "${row}" >> "$1"
   done
-  # nice to have newline separating this entry and the next
-  echo "" >> "$1"
 }
 
 # Handle termination signals and write output

--- a/writenow
+++ b/writenow
@@ -113,6 +113,8 @@ function write_lines() {
   for row in "${ROW_LINES[@]}"; do
     echo "${row}" >> "$1"
   done
+  # nice to have newline separating this entry and the next
+  echo "" >> "$1"
 }
 
 # Handle termination signals

--- a/writenow
+++ b/writenow
@@ -22,7 +22,6 @@ readonly PROMPT="> "
 readonly ERROR_COLOR="1"
 readonly SECOND_COLOR="8"
 declare -r -i MAX_ROWS=3
-declare TEMINATED=false
 declare -i ROWS=0
 declare ROW_LINES=()
 
@@ -63,8 +62,12 @@ function usage() {
   echo
   echo "Usage: writenow [OPTION]..."
   echo
+  echo "  Upon exit, writenow will create a file at ~/prose/\$(date +%Y-%m-%d).txt"
+  echo "  if it does not already exist, and then append the lines you've written."
+  echo
   echo "  -h, --help      display this help and exit"
   echo "  -v, --version   display version information and exit"
+  echo
 }
 
 # Parse arguments
@@ -110,18 +113,13 @@ function write_lines() {
 }
 
 # Handle termination signals
-# Globals: TEMINATED
 function handle_termination() {
-  if ! $TEMINATED; then
-    TEMINATED=true
-    echo
-    read -r -p "File name to write: " file
-    write_lines "${file}"
-    exit 0
-  else
-    echo
-    exit 0
-  fi
+  mkdir -p "$HOME/prose"
+  local OUTPATH="$HOME/prose/$(date +%Y-%m-%d).txt"
+  write_lines "${OUTPATH}"
+  echo
+  echo "added ${#ROW_LINES[@]} lines to ${OUTPATH}" >&2
+  exit 0
 }
 
 # Clear prompt lines if exceeds MAX_ROWS and set the foreground color


### PR DESCRIPTION
This means users can create an alias like `writenow -o ~/notes/$(date +%Y-%m-%d).txt`
But you can still choose a filename upon exit if you don't use `-o`